### PR TITLE
fix: packages counting on startup message

### DIFF
--- a/init.el
+++ b/init.el
@@ -286,7 +286,7 @@
 ;;    Packages     : %s
 "
                          (emacs-init-time)
-                         (number-to-string (length package-activated-list))))))))
+                         (length (hash-table-keys straight--recipe-cache))))))))
 
 
 ;;; WINDOW


### PR DESCRIPTION
We now count packages installed by `straight.el`, not internal `packages.el`.

<img width="344" height="89" alt="image" src="https://github.com/user-attachments/assets/ecf5b0f8-be11-4010-a991-0d3a754c38ef" />
